### PR TITLE
Error Response has wrong Content-Type header

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-module/carbon/v2"
@@ -11,7 +10,20 @@ import (
 )
 
 func main() {
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c *fiber.Ctx, err error) error {
+			code := fiber.StatusInternalServerError
+
+			var e *fiber.Error
+			if errors.As(err, &e) {
+				code = e.Code
+			}
+
+			return c.Status(code).JSON(map[string]string{
+				"message": err.Error(),
+			})
+		},
+	})
 
 	app.All("/", func(c *fiber.Ctx) error {
 		queryYear := c.Query("year", carbon.Now().Format("Y"))
@@ -19,13 +31,13 @@ func main() {
 		year, err := strconv.Atoi(queryYear)
 
 		if err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, getJSONError("the year must be an integer"))
+			return fiber.NewError(fiber.StatusUnprocessableEntity, "the year must be an integer")
 		}
 
 		holidays, err := getHolidays(year)
 
 		if err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, getJSONError(err.Error()))
+			return fiber.NewError(fiber.StatusUnprocessableEntity, err.Error())
 		}
 
 		return c.JSON(holidays)
@@ -116,16 +128,7 @@ func getHolidays(year int) ([15]Holiday, error) {
 	return holidays, nil
 }
 
-func getJSONError(message string) string {
-	err, _ := json.Marshal(Error{message})
-	return string(err)
-}
-
 type Holiday struct {
 	Name string `json:"name"`
 	Date string `json:"date"`
-}
-
-type Error struct {
-	Message string `json:"message"`
 }

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func getHolidays(year int) ([15]Holiday, error) {
 		return [15]Holiday{}, errors.New("the year must be greater than 325")
 	}
 
-	easter := carbon.Time2Carbon(orthodoxEaster)
+	easter := carbon.CreateFromStdTime(orthodoxEaster)
 	secondDayOfEaster := easter.AddDay()
 	goodFriday := easter.SubDays(2)
 	whitMonday := easter.AddDays(50)


### PR DESCRIPTION
Closes #16 

What's been done:
- Added custom error handler that transforms marshals the error on the fly
- Removed no-longer needed `getJSONError()` function and `Error` struct
- Refactored deprecated carbon.Time2Carbon() to carbon.CreateFromStdString()